### PR TITLE
docs: Add Korean translation for part of diversity policy

### DIFF
--- a/docs/legal/ethos/diversity.md
+++ b/docs/legal/ethos/diversity.md
@@ -2,10 +2,11 @@
 
 The Ubuntu project welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
 
-Standards for behaviour in the Ubuntu community are detailed in the [Code of Conduct](./code-of-conduct) and [Leadership Code of Conduct](./code-of-conduct#leadership). We expect participants in our community to meet these standards in all their interactions and to help others to do so as well.
+우분투 커뮤니티의 행동 기준은 [행동 강령](./code-of-conduct) 및 [리더십 행동 강령](./code-of-conduct#leadership)에 자세하게 설명되어있습니다. 우리 커뮤니티의 참가자들이 모든 상호작용에서 이러한 기준을 충족하고 다른 사람들도 이를 준수할 수 있도록 도와줄 것으로 기대합니다.
 
 Whenever any participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
 
 Although this list cannot be exhaustive, we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socio-economic status, subculture and technical ability.
 
 Some of the ideas and wording for this statement were based on diversity statements from the [Python community](https://www.python.org/community/diversity/) and [Dreamwidth Studios](https://www.dreamwidth.org/legal/diversity) (CC-BY-SA 3.0).
+


### PR DESCRIPTION
Updated the diversity policy document to include a Korean translation of the behavior standards.